### PR TITLE
Updates guzzle in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7",


### PR DESCRIPTION
The guzzle version was way outdated! Did a pull request a month ago, but for some reason it didn't got merged into the master? Even though the moderators accepted this.

So please, this time verify a correct merge. Else we won't be able to use this library anymore. All larger frameworks (like Laravel) require a newer version of Guzzle.

This update in composer.json does not break anything.