### PR TITLE
Setting minimum version of PHP to 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": ">=7.0",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",


### PR DESCRIPTION
Most API classes declare a method called "list", but thats a [reserved keyword](https://www.php.net/manual/en/reserved.keywords.php) in PHP < 7.0 so this library is incompatible with lower versions.